### PR TITLE
Simplified and clarified makefile

### DIFF
--- a/Snow17SacUH/src_bin/driver/Makefile
+++ b/Snow17SacUH/src_bin/driver/Makefile
@@ -7,19 +7,46 @@
 #           Jan 2016, renamed some subroutines, replaced several for code
 #                     that now runs in distributed fashion
 #           Aug 2015, major overhaul of code, updated makefile
+#  Elizabeth Clark, Feb 2017, adding documentation and separating executable
+#                     from FC and FC77 definitions so that flags set
+#                     properly even if compiler path is needed. Moved compiler
+#                     type and executable to PART 0 so that user will be
+#                     more likely to set it
 #
 #========================================================================
 # PART 0: Define directory paths
 #========================================================================
 
 # Define core directory below which everything resides
-F_MASTER_DIR = /home/andywood/proj/overtheloop/models/code/NWS_hydro_models/Snow17SacUH/src_bin/
+F_MASTER_DIR = NWS_hydro_models/Snow17SacUH/src_bin/
 
 # Location of the compiled modules
 MOD_PATH = $(F_MASTER_DIR)/driver
 
 # Define the executable and path
 EXE = $(F_MASTER_DIR)/Snow17SacUH.exe
+
+# Define the Fortran Compiler type
+# This is used in if statements in this makefile to define flags that are
+# specific to each compiler.
+# DO NOT SPECIFY the full path to the executable here. You can do so below
+#FC  = pgf90
+#FC77 = pgf77
+#FC  = ifort
+#FC77 = ifort
+FC  = gfortran
+FC77 = gfortran
+
+# Define the Fortran Compiler executable
+# This is not used in the if statements in this makefile, but simply to do
+# the actual compilation.
+# MAKE SURE this is consistent with the compiler type defined above
+#FCEXE = /opt/pgi-15.7/linux86-64/15.7/bin/pgf90
+#FC77EXE = /opt/pgi-15.7/linux86-64/15.7/bin/pgf77
+#FCEXE  = ifort
+#FC77EXE = ifort
+FCEXE  = gfortran
+FC77EXE = gfortran
 
 #========================================================================
 # PART 1: Assemble all of the various sub-routines
@@ -71,27 +98,15 @@ sac_77 = $(patsubst %, $(sac_dir)/%, $(calib_sac_77))
 # PART 2: Define the libraries, driver programs, and executables
 #========================================================================
 
-# Define the Fortran Compilers
-#FC  = /opt/pgi-15.7/linux86-64/15.7/bin/pgf90
-#FC77 = /opt/pgi-15.7/linux86-64/15.7/bin/pgf77
-
-#FC  = ifort
-#FC77 = ifort
-
-FC  = gfortran  # DO NOT USE GFORTRAN UNTIL BUG IS FOUND
-FC77 = gfortran
-
 # Define the libraries and path to include files
 ifeq "$(FC)" "pgf90"
  LOCL_PATH = /usr/local
-
  LIB = -L$(LOCL_PATH)/lib 
  INC = -I ./
 endif
 
 ifeq "$(FC77)" "pgf77"
  LOCL_PATH = /usr/local
-
  LIB77 = -L$(LOCL_PATH)/lib 
  INC77 = -I ./
 endif
@@ -107,40 +122,40 @@ DRIVER = $(patsubst %, $(DRIVER_DIR)/%, $(calib_DRIVER))
 
 # Define flags
 ifeq "$(FC)" "gfortran"
-  FLAGS_DEBUG = -static -Wall -g -ffixed-line-length-none
-  FLAGS77 = -O3 -fno-align-commons -ffixed-line-length-none
-  FLAGS = -O3 -fno-align-commons -ffixed-line-length-none
-  FLAGS2 = -O3 -fno-align-commons -ffixed-line-length-none
-#  FLAGS = -O3 -fdefault-real-8 -fno-align-commons -fixed-line-length-none
-#  FLAGS2 = -O3 -fdefault-real-8 -fno-align-commons -fixed-line-length-none
+  # do not use -fdefault-real-8 since this will change the outcomes
+  FLAGS_DEBUG = -static -Wall -g -fixed-line-length-none
+  FLAGS = -O3 -fno-align-commons -fixed-line-length-none
+  FLAGS2 = -O3 -fno-align-commons -fixed-line-length-none
 endif
 
 ifeq "$(FC)" "ifort"
+  # do not use -autodouble since this will change the outcomes
   FLAGS_PROF = -static -debug -warn all -check all -FR -O0 -auto -WB -traceback -g -fltconsistency -fpe0
-  FLAGS_DEBUG = -static -debug -warn all -check all -FR -O0 -auto -WB -traceback -g -fltconsistency -fpe0
-  FLAGS77 = -O3 -f77rtl 
   FLAGS = -O3 -warn all -check all
-  FLAGS2 = -O3 
+  FLAGS2 = -O3
 endif
 
 ifeq "$(FC)" "pgf90"
+  # do not use -r8 since this will change the outcomes
   FLAGS_PROF = -Bstatic -Mbackslash -g -Mchkptr -Mchkstk -Mpgicoff -Minform=inform -Ktrap=divz,inv -Mprof=lines,time
-  FLAGS_DEBUG = -Bstatic -Mbackslash -g -Mchkptr -Mchkstk -Mpgicoff -Minform=inform -Ktrap=divz,inv -Mprof=lines,time
-  # FLAGS = -Mfreeform -O3 -Mbackslash -g -Mchkptr -Mchkstk -Mpgicoff -Minform=inform -Ktrap=divz,inv
-  FLAGS = -O3 -r8 -Kieee
-  FLAGS2 = -O3 -r8
+  FLAGS = -O3 -Kieee
+  FLAGS2 = -O3
+endif
+
+ifeq "$(FC77)" "gfortran"
+  # do not use -fdefault-real-8 since this will change the outcomes
+  FLAGS77 = -O3 -fno-align-commons -fixed-line-length-none
+endif
+
+ifeq "$(FC77)" "ifort"
+  # do not use -autodouble since this will change the outcomes
+  FLAGS77 = -O3 -f77rtl
 endif
 
 ifeq "$(FC77)" "pgf77"
-  FLAGS77 = -O3 -r8
+  # do not use -r8 since this will change the outcomes
+  FLAGS77 = -O3
 endif
-ifeq "$(FC77)" "gfortran"
-  FLAGS77 = -O3 -fdefault-real-8 -fno-align-commons -ffree-line-length-none
-endif
-
-#FLAGS = -O3 -W -v
-
-#.SUFFIXES: .f .o .f90
 
 # -- Compile --
 
@@ -149,24 +164,23 @@ debug: compile_debug link
 
 check:
 	echo test
-	echo $(FC)
+	echo $(FCEXE)
 
 # compile calibration code
 compile_calib:
-	$(FC77) $(FLAGS77) -c $(sac_77) $(INC77)
-	$(FC) $(FLAGS2) -c $(snow19) $(INC)
-	$(FC) $(FLAGS) -c $(UTIL) $(DRIVER) \
+	$(FC77EXE) $(FLAGS77) -c $(sac_77) $(INC77)
+	$(FCEXE) $(FLAGS2) -c $(snow19) $(INC)
+	$(FCEXE) $(FLAGS) -c $(UTIL) $(DRIVER) \
 	$(INC)
 
 compile_debug:
-	$(FC77) $(FLAGS77) -g -fcheck=all -c $(sac_77) $(INC77)
-	$(FC) $(FLAGS2) -g -fcheck=all -c $(snow19) $(INC)
-	$(FC) $(FLAGS) -g -fcheck=all -c $(UTILS) $(DRIVER) \
+	$(FC77EXE) $(FLAGS77) -g -fcheck=all -c $(sac_77) $(INC77)
+	$(FCEXE) $(FLAGS2) -g -fcheck=all -c $(snow19) $(INC)
+	$(FCEXE) $(FLAGS) -g -fcheck=all -c $(UTILS) $(DRIVER) \
 	$(INC)
 
 # link routines
 link:
-#	$(FC) -fPIC -Bstatic_pgi -rpath,/usr/local/netcdf4-pgi/lib *.o -I./ $(LIBNETCDF) -o $(EXE)
 	$(FC) -fPIC -I./ $(LIB) -o $(EXE) *.o 
 
 # Remove object files

--- a/Snow17SacUH/src_bin/driver/Makefile
+++ b/Snow17SacUH/src_bin/driver/Makefile
@@ -18,7 +18,7 @@
 #========================================================================
 
 # Define core directory below which everything resides
-F_MASTER_DIR = NWS_hydro_models/Snow17SacUH/src_bin/
+F_MASTER_DIR = /home/hydrofcst/SHARP/models/code/NWS_hydro_models/Snow17SacUH/src_bin/
 
 # Location of the compiled modules
 MOD_PATH = $(F_MASTER_DIR)/driver

--- a/Snow17SacUH/src_bin/driver/Makefile
+++ b/Snow17SacUH/src_bin/driver/Makefile
@@ -123,9 +123,9 @@ DRIVER = $(patsubst %, $(DRIVER_DIR)/%, $(calib_DRIVER))
 # Define flags
 ifeq "$(FC)" "gfortran"
   # do not use -fdefault-real-8 since this will change the outcomes
-  FLAGS_DEBUG = -static -Wall -g -fixed-line-length-none
-  FLAGS = -O3 -fno-align-commons -fixed-line-length-none
-  FLAGS2 = -O3 -fno-align-commons -fixed-line-length-none
+  FLAGS_DEBUG = -static -Wall -g -ffixed-line-length-none
+  FLAGS = -O3 -fno-align-commons -ffixed-line-length-none
+  FLAGS2 = -O3 -fno-align-commons -ffixed-line-length-none
 endif
 
 ifeq "$(FC)" "ifort"
@@ -144,7 +144,7 @@ endif
 
 ifeq "$(FC77)" "gfortran"
   # do not use -fdefault-real-8 since this will change the outcomes
-  FLAGS77 = -O3 -fno-align-commons -fixed-line-length-none
+  FLAGS77 = -O3 -fno-align-commons -ffixed-line-length-none
 endif
 
 ifeq "$(FC77)" "ifort"


### PR DESCRIPTION
This PR has 3 primary changes:
1. Following on issue #13, this PR removes the options to use `-autodouble` with `ifort`, `-r8` with PGI compilers, and `-fdefault-real-8` with `gfortran` because results are only reproducible between compilers without these flags.
2. If the `FC` and `FC77` variables were set to a full executable in original Makefile, the `if` statements would not be triggered and compiler flags would not be assigned. To get around this, this PR sets separate variables `FCEXE` and `FC77EXE` to allow user to set a compiler executable path without impacting flag definitions. I moved these variable definitions to the top of the Makefile so that users will be more likely to see that they need to set these values.
3. General clean-up, removal of commented code, addition of documentation.